### PR TITLE
Implement IngredientQuantity as a value and an optional unit

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -30,6 +30,6 @@ manage their ingredients inventory and shopping list.
 == Acknowledgements
 
 * This application was built on the excellent AddressBook-Level3 project created by link:https://se-education.org[SE-EDU] initiative.
-* Libraries used: https://openjfx.io/[JavaFX], https://github.com/FasterXML/jackson[Jackson], https://github.com/junit-team/junit5[JUnit5]
+* Libraries used: https://openjfx.io/[JavaFX], https://github.com/FasterXML/jackson[Jackson], https://github.com/junit-team/junit5[JUnit5], https://commons.apache.org/proper/commons-math/[Apache Commons Math]
 
 == Licence : link:LICENSE[MIT]

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ dependencies {
     String jUnitVersion = '5.4.0'
     String javaFxVersion = '11'
 
+    compile group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
+
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'win'
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'mac'
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'linux'

--- a/src/main/java/seedu/address/commons/core/fraction/MixedFraction.java
+++ b/src/main/java/seedu/address/commons/core/fraction/MixedFraction.java
@@ -1,5 +1,8 @@
 package seedu.address.commons.core.fraction;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
 import org.apache.commons.math3.fraction.Fraction;
 
 /**
@@ -7,27 +10,25 @@ import org.apache.commons.math3.fraction.Fraction;
  */
 public class MixedFraction extends Fraction {
     private static final int NUM_OF_PARTS_IN_PURE_FRACTION = 1;
-    private static final int WHOLE_NUMBER_PART_OF_PURE_FRACTION = 0;
-    private static final int FRACTION_PART_POSITION_IN_PURE_FRACTION = 0;
+    private static final int WHOLE_PART_OF_PURE_FRACTION = 0;
+    private static final int FRACTIONAL_PART_POSITION_IN_PURE_FRACTION = 0;
     private static final int NUM_OF_PARTS_IN_MIXED_FRACTION = 2;
-    private static final int WHOLE_NUMBER_PART_POSITION_IN_MIXED_FRACTION = 0;
-    private static final int FRACTION_PART_POSITION_IN_MIXED_FRACTION = 1;
+    private static final int WHOLE_PART_POSITION_IN_MIXED_FRACTION = 0;
+    private static final int FRACTIONAL_PART_POSITION_IN_MIXED_FRACTION = 1;
     private static final int NUM_OF_PARTS_IN_FRACTION = 2;
     private static final int NUMERATOR_POSITION = 0;
     private static final int DENOMINATOR_POSITION = 1;
 
-    public MixedFraction(int value) {
-        super(value);
-    }
-
-    public MixedFraction(double value) {
-        super(value);
-    }
-
+    /**
+     * Constructs a {@code MixedFraction} from a {@code Fraction}.
+     */
     public MixedFraction(Fraction f) {
         super(f.getNumerator(), f.getDenominator());
     }
 
+    /**
+     * Constructs a {@code MixedFraction} from a numerator and a denominator.
+     */
     public MixedFraction(int num, int den) {
         super(num, den);
     }
@@ -44,53 +45,85 @@ public class MixedFraction extends Fraction {
             throw new NumberFormatException("null");
         }
 
-        int wholeNumberPart;
-        int fractionPosition;
+        int wholePart;
+        int fractionalPartPosition;
         String[] splitInput = s.split("\\s+");
         if (splitInput.length == NUM_OF_PARTS_IN_PURE_FRACTION) {
-            wholeNumberPart = WHOLE_NUMBER_PART_OF_PURE_FRACTION;
-            fractionPosition = FRACTION_PART_POSITION_IN_PURE_FRACTION;
+            wholePart = WHOLE_PART_OF_PURE_FRACTION;
+            fractionalPartPosition = FRACTIONAL_PART_POSITION_IN_PURE_FRACTION;
         } else if (splitInput.length == NUM_OF_PARTS_IN_MIXED_FRACTION) {
-            wholeNumberPart = Integer.parseInt(splitInput[WHOLE_NUMBER_PART_POSITION_IN_MIXED_FRACTION]);
-            fractionPosition = FRACTION_PART_POSITION_IN_MIXED_FRACTION;
+            wholePart = Integer.parseInt(splitInput[WHOLE_PART_POSITION_IN_MIXED_FRACTION]);
+            fractionalPartPosition = FRACTIONAL_PART_POSITION_IN_MIXED_FRACTION;
         } else {
             throw new NumberFormatException(s);
         }
 
-        String[] splitFraction = splitInput[fractionPosition].split("/");
+        String[] splitFraction = splitInput[fractionalPartPosition].split("/");
         if (splitFraction.length != NUM_OF_PARTS_IN_FRACTION) {
             throw new NumberFormatException(s);
         }
 
         int numerator = Integer.parseInt(splitFraction[NUMERATOR_POSITION]);
         int denominator = Integer.parseInt(splitFraction[DENOMINATOR_POSITION]);
-        numerator += wholeNumberPart * denominator;
+        numerator += wholePart * denominator;
         return new MixedFraction(numerator, denominator);
     }
 
     /**
-     * Adds two {@code MixedFraction} values together.
+     * Returns the {@code MixedFraction} representation of a {@code BigDecimal} value.
+     *
+     * @param value the {@code BigDecimal} value.
+     * @return the {@code MixedFraction} representation of the {@code BigDecimal} value.
      */
-    public static MixedFraction sum(MixedFraction a, MixedFraction b) {
-        return new MixedFraction(a.add(b));
+    public static MixedFraction getFromBigDecimal(BigDecimal value) {
+        String stringRepresentation = value.toString();
+        boolean hasFractionalPart = stringRepresentation.split("\\.").length > 1;
+        int wholePart = Integer.parseInt(stringRepresentation.split("\\.")[0]);
+        int numerator = wholePart;
+        int denominator = 1;
+
+        if (hasFractionalPart) {
+            String fractionalPartString = stringRepresentation.split("\\.")[1];
+            denominator = new BigInteger("10").pow(fractionalPartString.length()).intValue();
+            if (numerator >= 0) {
+                numerator = wholePart * denominator + Integer.parseInt(fractionalPartString);
+            } else {
+                numerator = wholePart * denominator - Integer.parseInt(fractionalPartString);
+            }
+        }
+        return new MixedFraction(numerator, denominator);
     }
 
     /**
-     * Return the additive inverse of this mixed fraction.
+     * Adds the specified mixed fraction.
      */
-    public MixedFraction negate() {
-        return new MixedFraction(super.negate());
+    public MixedFraction add(MixedFraction mixedFraction) {
+        return new MixedFraction(super.add(mixedFraction));
+    }
+
+    /**
+     * Subtracts the specified mixed fraction.
+     */
+    public MixedFraction subtract(MixedFraction mixedFraction) {
+        return new MixedFraction(super.subtract(mixedFraction));
     }
 
     @Override
     public String toString() {
-        int wholeNumberPart = intValue();
+        int wholePart = intValue();
+        int numerator = getNumerator();
         int denominator = getDenominator();
-        int numerator = getNumerator() - (wholeNumberPart * denominator);
+        if (numerator > 0) {
+            numerator = numerator - (wholePart * denominator);
+        } else if (wholePart < 0) {
+            numerator = (wholePart * denominator) - numerator;
+        }
 
-        if (wholeNumberPart == 0) {
+        if (numerator == 0) {
+            return "0";
+        } else if (wholePart == 0) {
             return String.format("%d/%d", numerator, denominator);
         }
-        return String.format("%d %d/%d", wholeNumberPart, numerator, denominator);
+        return String.format("%d %d/%d", wholePart, numerator, denominator);
     }
 }

--- a/src/main/java/seedu/address/commons/core/fraction/MixedFraction.java
+++ b/src/main/java/seedu/address/commons/core/fraction/MixedFraction.java
@@ -87,6 +87,10 @@ public class MixedFraction extends Fraction {
         int wholeNumberPart = intValue();
         int denominator = getDenominator();
         int numerator = getNumerator() - (wholeNumberPart * denominator);
+
+        if (wholeNumberPart == 0) {
+            return String.format("%d/%d", numerator, denominator);
+        }
         return String.format("%d %d/%d", wholeNumberPart, numerator, denominator);
     }
 }

--- a/src/main/java/seedu/address/commons/core/fraction/MixedFraction.java
+++ b/src/main/java/seedu/address/commons/core/fraction/MixedFraction.java
@@ -1,0 +1,66 @@
+package seedu.address.commons.core.fraction;
+
+import org.apache.commons.math3.fraction.Fraction;
+
+/**
+ * Represents a non-negative mixed fraction.
+ */
+public class MixedFraction extends Fraction {
+    private static final int NUM_OF_PARTS_IN_PURE_FRACTION = 1;
+    private static final int WHOLE_NUMBER_PART_OF_PURE_FRACTION = 0;
+    private static final int FRACTION_PART_POSITION_IN_PURE_FRACTION = 0;
+    private static final int NUM_OF_PARTS_IN_MIXED_FRACTION = 2;
+    private static final int WHOLE_NUMBER_PART_POSITION_IN_MIXED_FRACTION = 0;
+    private static final int FRACTION_PART_POSITION_IN_MIXED_FRACTION = 1;
+    private static final int NUM_OF_PARTS_IN_FRACTION = 2;
+    private static final int NUMERATOR_POSITION = 0;
+    private static final int DENOMINATOR_POSITION = 1;
+
+    private MixedFraction(int num, int den) {
+        super(num, den);
+    }
+
+    /**
+     * Parses the string argument as a mixed fraction.
+     *
+     * @param s a {@code String} containing the {@code MixedFraction} representation to be parsed
+     * @return the mixed fraction value represented by the argument.
+     * @throws NumberFormatException if the string does not contain a parsable mixed fraction.
+     */
+    public static MixedFraction parseMixedFraction(String s) {
+        if (s == null) {
+            throw new NumberFormatException("null");
+        }
+
+        int wholeNumberPart;
+        int fractionPosition;
+        String[] splitInput = s.split("\\s+");
+        if (splitInput.length == NUM_OF_PARTS_IN_PURE_FRACTION) {
+            wholeNumberPart = WHOLE_NUMBER_PART_OF_PURE_FRACTION;
+            fractionPosition = FRACTION_PART_POSITION_IN_PURE_FRACTION;
+        } else if (splitInput.length == NUM_OF_PARTS_IN_MIXED_FRACTION) {
+            wholeNumberPart = Integer.parseInt(splitInput[WHOLE_NUMBER_PART_POSITION_IN_MIXED_FRACTION]);
+            fractionPosition = FRACTION_PART_POSITION_IN_MIXED_FRACTION;
+        } else {
+            throw new NumberFormatException(s);
+        }
+
+        String[] splitFraction = splitInput[fractionPosition].split("/");
+        if (splitFraction.length != NUM_OF_PARTS_IN_FRACTION) {
+            throw new NumberFormatException(s);
+        }
+
+        int numerator = Integer.parseInt(splitFraction[NUMERATOR_POSITION]);
+        int denominator = Integer.parseInt(splitFraction[DENOMINATOR_POSITION]);
+        numerator += wholeNumberPart * denominator;
+        return new MixedFraction(numerator, denominator);
+    }
+
+    @Override
+    public String toString() {
+        int wholeNumberPart = intValue();
+        int denominator = getDenominator();
+        int numerator = getNumerator() - (wholeNumberPart * denominator);
+        return String.format("%d %d/%d", wholeNumberPart, numerator, denominator);
+    }
+}

--- a/src/main/java/seedu/address/commons/core/fraction/MixedFraction.java
+++ b/src/main/java/seedu/address/commons/core/fraction/MixedFraction.java
@@ -3,7 +3,7 @@ package seedu.address.commons.core.fraction;
 import org.apache.commons.math3.fraction.Fraction;
 
 /**
- * Represents a non-negative mixed fraction.
+ * Represents a mixed fraction.
  */
 public class MixedFraction extends Fraction {
     private static final int NUM_OF_PARTS_IN_PURE_FRACTION = 1;
@@ -16,18 +16,30 @@ public class MixedFraction extends Fraction {
     private static final int NUMERATOR_POSITION = 0;
     private static final int DENOMINATOR_POSITION = 1;
 
-    private MixedFraction(int num, int den) {
+    public MixedFraction(int value) {
+        super(value);
+    }
+
+    public MixedFraction(double value) {
+        super(value);
+    }
+
+    public MixedFraction(Fraction f) {
+        super(f.getNumerator(), f.getDenominator());
+    }
+
+    public MixedFraction(int num, int den) {
         super(num, den);
     }
 
     /**
-     * Parses the string argument as a mixed fraction.
+     * Parses the string argument as an unsigned mixed fraction.
      *
      * @param s a {@code String} containing the {@code MixedFraction} representation to be parsed
      * @return the mixed fraction value represented by the argument.
-     * @throws NumberFormatException if the string does not contain a parsable mixed fraction.
+     * @throws NumberFormatException if the string does not contain a parsable unsigned mixed fraction.
      */
-    public static MixedFraction parseMixedFraction(String s) {
+    public static MixedFraction parseUnsignedMixedFraction(String s) {
         if (s == null) {
             throw new NumberFormatException("null");
         }
@@ -54,6 +66,20 @@ public class MixedFraction extends Fraction {
         int denominator = Integer.parseInt(splitFraction[DENOMINATOR_POSITION]);
         numerator += wholeNumberPart * denominator;
         return new MixedFraction(numerator, denominator);
+    }
+
+    /**
+     * Adds two {@code MixedFraction} values together.
+     */
+    public static MixedFraction sum(MixedFraction a, MixedFraction b) {
+        return new MixedFraction(a.add(b));
+    }
+
+    /**
+     * Return the additive inverse of this mixed fraction.
+     */
+    public MixedFraction negate() {
+        return new MixedFraction(super.negate());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ingredient/IngredientQuantity.java
+++ b/src/main/java/seedu/address/model/ingredient/IngredientQuantity.java
@@ -3,6 +3,12 @@ package seedu.address.model.ingredient;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import seedu.address.commons.core.fraction.MixedFraction;
+
 /**
  * Represents the quantity of an ingredient.
  * Guarantees: immutable; is always valid
@@ -10,15 +16,27 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class IngredientQuantity {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Ingredient quantities should only contain alphanumeric characters, spaces, and punctuation, "
-            + "and it should start with a decimal digit";
+            "Ingredient quantities should only contain a value and a unit, where the value can be "
+            + "whole numbers, decimals, or fractions, and the unit should only contain alphabets";
+
+    public static final String WHOLE_NUMBER_REGEX = "[\\p{Digit}]+ *";
+    public static final String DECIMAL_REGEX = "[\\p{Digit}]*\\.[\\p{Digit}]+ *";
+    public static final String FRACTION_REGEX = "[\\p{Digit}]+( +[\\p{Digit}]+)?/[\\p{Digit}]+ *";
+    public static final String UNIT_REGEX = "[\\p{Alpha}][\\p{Alpha} ]*";
 
     /*
-     * The first character of the ingredient quantity must be a decimal digit.
+     * The ingredient quantity must consist of a whole number, decimal, or fraction, and an optional unit.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Digit}][\\p{Graph} ]*";
+    public static final String VALIDATION_REGEX = String.format("((%s)|(%s)|(%s))(%s)?",
+            WHOLE_NUMBER_REGEX, DECIMAL_REGEX, FRACTION_REGEX, UNIT_REGEX);
 
-    public final String ingredientQuantity;
+    public static final Pattern WHOLE_NUMBER_PATTERN = Pattern.compile(WHOLE_NUMBER_REGEX);
+    public static final Pattern DECIMAL_PATTERN = Pattern.compile(DECIMAL_REGEX);
+    public static final Pattern FRACTION_PATTERN = Pattern.compile(FRACTION_REGEX);
+    public static final Pattern UNIT_PATTERN = Pattern.compile(UNIT_REGEX);
+
+    public final Number value;
+    public final String unit;
 
     /**
      * Constructs an {@code IngredientQuantity}.
@@ -28,7 +46,8 @@ public class IngredientQuantity {
     public IngredientQuantity(String ingredientQuantity) {
         requireNonNull(ingredientQuantity);
         checkArgument(isValidIngredientQuantity(ingredientQuantity), MESSAGE_CONSTRAINTS);
-        this.ingredientQuantity = ingredientQuantity;
+        this.value = parseValue(ingredientQuantity);
+        this.unit = parseUnit(ingredientQuantity);
     }
 
     /**
@@ -38,22 +57,55 @@ public class IngredientQuantity {
         return test.matches(VALIDATION_REGEX);
     }
 
+    /**
+     * Returns the value of an ingredient's quantity.
+     *
+     * @param ingredientQuantity The given string representing an ingredient's quantity.
+     * @return The value of the ingredient's IngredientQuantity.
+     */
+    private static Number parseValue(String ingredientQuantity) {
+        Matcher wholeNumberMatcher = WHOLE_NUMBER_PATTERN.matcher(ingredientQuantity);
+        Matcher decimalMatcher = DECIMAL_PATTERN.matcher(ingredientQuantity);
+        Matcher mixedFractionMatcher = FRACTION_PATTERN.matcher(ingredientQuantity);
+        if (decimalMatcher.find()) {
+            return Double.parseDouble(decimalMatcher.group().trim());
+        } else if (mixedFractionMatcher.find()) {
+            return MixedFraction.parseMixedFraction(mixedFractionMatcher.group().trim());
+        } else if (wholeNumberMatcher.find()) {
+            return Integer.parseInt(wholeNumberMatcher.group().trim());
+        }
+        assert false;
+        return null;
+    }
+
+    /**
+     * Returns the unit of an ingredient's quantity.
+     *
+     * @param ingredientQuantity The given string representing an ingredient's quantity.
+     * @return The unit of the ingredient's IngredientQuantity.
+     */
+    private static String parseUnit(String ingredientQuantity) {
+        Matcher unitMatcher = UNIT_PATTERN.matcher(ingredientQuantity);
+        unitMatcher.find();
+        return unitMatcher.group().trim();
+    }
+
     @Override
     public String toString() {
-        return ingredientQuantity;
+        return String.format("%s %s", value, unit);
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof IngredientQuantity // instanceof handles nulls
-                && ingredientQuantity.toLowerCase()
-                        .equals(((IngredientQuantity) other).ingredientQuantity.toLowerCase())); // state check
+                && value.equals(((IngredientQuantity) other).value)
+                && unit.equals(((IngredientQuantity) other).unit));
     }
 
     @Override
     public int hashCode() {
-        return ingredientQuantity.toLowerCase().hashCode();
+        return Objects.hash(value, unit);
     }
 
 }

--- a/src/main/java/seedu/address/model/ingredient/IngredientQuantity.java
+++ b/src/main/java/seedu/address/model/ingredient/IngredientQuantity.java
@@ -73,7 +73,7 @@ public class IngredientQuantity {
     }
 
     /**
-     * Adds the specified ingredient quantity to the ingredient quantity.
+     * Adds the specified ingredient quantity to the ingredient quantity, if the ingredient quantities are compatible.
      *
      * @param other the ingredient quantity to be added.
      * @return a new ingredient quantity with the specified ingredient quantity added.
@@ -103,7 +103,8 @@ public class IngredientQuantity {
     }
 
     /**
-     * Subtracts the specified ingredient quantity from the ingredient quantity.
+     * Subtracts the specified ingredient quantity from the ingredient quantity, if the ingredient quantities are
+     * compatible.
      * If the specified ingredient quantity is larger, the value of the ingredient quantity returned will be 0.
      *
      * @param other the ingredient quantity to be subtracted.

--- a/src/main/java/seedu/address/model/ingredient/IngredientQuantity.java
+++ b/src/main/java/seedu/address/model/ingredient/IngredientQuantity.java
@@ -35,7 +35,7 @@ public class IngredientQuantity {
     private static final Pattern FRACTION_PATTERN = Pattern.compile(FRACTION_REGEX);
     private static final Pattern UNIT_PATTERN = Pattern.compile(UNIT_REGEX);
 
-    private static final int LARGEST_DENOMINATOR = 4;
+    private static final int LARGEST_DENOMINATOR = 6;
 
     public final Number value;
     public final String unit;

--- a/src/test/java/seedu/address/commons/core/fraction/MixedFractionTest.java
+++ b/src/test/java/seedu/address/commons/core/fraction/MixedFractionTest.java
@@ -3,27 +3,67 @@ package seedu.address.commons.core.fraction;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.Assert.assertThrows;
 
+import org.apache.commons.math3.exception.NullArgumentException;
 import org.junit.jupiter.api.Test;
 
 public class MixedFractionTest {
     @Test
-    public void parseMixedFraction() {
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new MixedFraction(null));
+    }
+
+    @Test
+    public void parseUnsignedMixedFraction() {
         // null input
-        assertThrows(NumberFormatException.class, () -> MixedFraction.parseMixedFraction(null));
+        assertThrows(NumberFormatException.class, () -> MixedFraction.parseUnsignedMixedFraction(null));
 
         // invalid input
-        assertThrows(NumberFormatException.class, () -> MixedFraction.parseMixedFraction(""));
-        assertThrows(NumberFormatException.class, () -> MixedFraction.parseMixedFraction("null"));
-        assertThrows(NumberFormatException.class, () -> MixedFraction.parseMixedFraction("1"));
-        assertThrows(NumberFormatException.class, () -> MixedFraction.parseMixedFraction("1 / 2"));
-        assertThrows(NumberFormatException.class, () -> MixedFraction.parseMixedFraction("0.5"));
+        assertThrows(NumberFormatException.class, () -> MixedFraction.parseUnsignedMixedFraction(""));
+        assertThrows(NumberFormatException.class, () -> MixedFraction.parseUnsignedMixedFraction("null"));
+        assertThrows(NumberFormatException.class, () -> MixedFraction.parseUnsignedMixedFraction("1"));
+        assertThrows(NumberFormatException.class, () -> MixedFraction.parseUnsignedMixedFraction("1 / 2"));
+        assertThrows(NumberFormatException.class, () -> MixedFraction.parseUnsignedMixedFraction("0.5"));
 
         // valid input
-        assertEquals(0, MixedFraction.parseMixedFraction("1/2").intValue());
-        assertEquals(1, MixedFraction.parseMixedFraction("1/2").getNumerator());
-        assertEquals(2, MixedFraction.parseMixedFraction("1/2").getDenominator());
-        assertEquals(1, MixedFraction.parseMixedFraction("1 2/3").intValue());
-        assertEquals(5, MixedFraction.parseMixedFraction("1 2/3").getNumerator());
-        assertEquals(3, MixedFraction.parseMixedFraction("1 2/3").getDenominator());
+        assertEquals(0, MixedFraction.parseUnsignedMixedFraction("1/2").intValue());
+        assertEquals(1, MixedFraction.parseUnsignedMixedFraction("1/2").getNumerator());
+        assertEquals(2, MixedFraction.parseUnsignedMixedFraction("1/2").getDenominator());
+        assertEquals(1, MixedFraction.parseUnsignedMixedFraction("1 2/3").intValue());
+        assertEquals(5, MixedFraction.parseUnsignedMixedFraction("1 2/3").getNumerator());
+        assertEquals(3, MixedFraction.parseUnsignedMixedFraction("1 2/3").getDenominator());
+    }
+
+    @Test
+    public void sum() {
+        MixedFraction a = new MixedFraction(3, 2);
+        MixedFraction b = new MixedFraction(8, 3);
+        MixedFraction c = new MixedFraction(-5, 3);
+
+        // null input
+        assertThrows(NullPointerException.class, () -> MixedFraction.sum(null, null));
+        assertThrows(NullPointerException.class, () -> MixedFraction.sum(null, a));
+        assertThrows(NullArgumentException.class, () -> MixedFraction.sum(a, null));
+
+        // valid input
+        assertEquals(25, MixedFraction.sum(a, b).getNumerator());
+        assertEquals(6, MixedFraction.sum(a, b).getDenominator());
+        assertEquals(-1, MixedFraction.sum(a, c).getNumerator());
+        assertEquals(6, MixedFraction.sum(a, c).getDenominator());
+        assertEquals(1, MixedFraction.sum(b, c).getNumerator());
+        assertEquals(1, MixedFraction.sum(b, c).getDenominator());
+    }
+
+    @Test
+    public void negate() {
+        MixedFraction a = new MixedFraction(0, 1); // zero
+        MixedFraction b = new MixedFraction(1, 2); // positive
+        MixedFraction c = new MixedFraction(-2, 3); // negative
+
+        assertEquals(0, a.negate().getNumerator());
+        assertEquals(1, a.negate().getDenominator());
+        assertEquals(-1, b.negate().getNumerator());
+        assertEquals(2, b.negate().getDenominator());
+        assertEquals(2, c.negate().getNumerator());
+        assertEquals(3, c.negate().getDenominator());
     }
 }

--- a/src/test/java/seedu/address/commons/core/fraction/MixedFractionTest.java
+++ b/src/test/java/seedu/address/commons/core/fraction/MixedFractionTest.java
@@ -1,0 +1,29 @@
+package seedu.address.commons.core.fraction;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class MixedFractionTest {
+    @Test
+    public void parseMixedFraction() {
+        // null input
+        assertThrows(NumberFormatException.class, () -> MixedFraction.parseMixedFraction(null));
+
+        // invalid input
+        assertThrows(NumberFormatException.class, () -> MixedFraction.parseMixedFraction(""));
+        assertThrows(NumberFormatException.class, () -> MixedFraction.parseMixedFraction("null"));
+        assertThrows(NumberFormatException.class, () -> MixedFraction.parseMixedFraction("1"));
+        assertThrows(NumberFormatException.class, () -> MixedFraction.parseMixedFraction("1 / 2"));
+        assertThrows(NumberFormatException.class, () -> MixedFraction.parseMixedFraction("0.5"));
+
+        // valid input
+        assertEquals(0, MixedFraction.parseMixedFraction("1/2").intValue());
+        assertEquals(1, MixedFraction.parseMixedFraction("1/2").getNumerator());
+        assertEquals(2, MixedFraction.parseMixedFraction("1/2").getDenominator());
+        assertEquals(1, MixedFraction.parseMixedFraction("1 2/3").intValue());
+        assertEquals(5, MixedFraction.parseMixedFraction("1 2/3").getNumerator());
+        assertEquals(3, MixedFraction.parseMixedFraction("1 2/3").getDenominator());
+    }
+}

--- a/src/test/java/seedu/address/commons/core/fraction/MixedFractionTest.java
+++ b/src/test/java/seedu/address/commons/core/fraction/MixedFractionTest.java
@@ -3,6 +3,8 @@ package seedu.address.commons.core.fraction;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.Assert.assertThrows;
 
+import java.math.BigDecimal;
+
 import org.apache.commons.math3.exception.NullArgumentException;
 import org.junit.jupiter.api.Test;
 
@@ -34,36 +36,65 @@ public class MixedFractionTest {
     }
 
     @Test
-    public void sum() {
+    public void getFromBigDecimal() {
+        // integer
+        assertEquals(1, MixedFraction.getFromBigDecimal(new BigDecimal("1")).intValue());
+        assertEquals(1, MixedFraction.getFromBigDecimal(new BigDecimal("1")).getNumerator());
+        assertEquals(1, MixedFraction.getFromBigDecimal(new BigDecimal("1")).getDenominator());
+
+        // double
+        assertEquals(1, MixedFraction.getFromBigDecimal(new BigDecimal("1.2")).intValue());
+        assertEquals(6, MixedFraction.getFromBigDecimal(new BigDecimal("1.2")).getNumerator());
+        assertEquals(5, MixedFraction.getFromBigDecimal(new BigDecimal("1.2")).getDenominator());
+
+        // negative double
+        assertEquals(-1, MixedFraction.getFromBigDecimal(new BigDecimal("-1.2")).intValue());
+        assertEquals(-6, MixedFraction.getFromBigDecimal(new BigDecimal("-1.2")).getNumerator());
+        assertEquals(5, MixedFraction.getFromBigDecimal(new BigDecimal("-1.2")).getDenominator());
+    }
+
+    @Test
+    public void add() {
         MixedFraction a = new MixedFraction(3, 2);
         MixedFraction b = new MixedFraction(8, 3);
         MixedFraction c = new MixedFraction(-5, 3);
 
         // null input
-        assertThrows(NullPointerException.class, () -> MixedFraction.sum(null, null));
-        assertThrows(NullPointerException.class, () -> MixedFraction.sum(null, a));
-        assertThrows(NullArgumentException.class, () -> MixedFraction.sum(a, null));
+        assertThrows(NullArgumentException.class, () -> a.add(null));
 
         // valid input
-        assertEquals(25, MixedFraction.sum(a, b).getNumerator());
-        assertEquals(6, MixedFraction.sum(a, b).getDenominator());
-        assertEquals(-1, MixedFraction.sum(a, c).getNumerator());
-        assertEquals(6, MixedFraction.sum(a, c).getDenominator());
-        assertEquals(1, MixedFraction.sum(b, c).getNumerator());
-        assertEquals(1, MixedFraction.sum(b, c).getDenominator());
+        assertEquals(25, a.add(b).getNumerator());
+        assertEquals(6, a.add(b).getDenominator());
+        assertEquals(-1, a.add(c).getNumerator());
+        assertEquals(6, a.add(c).getDenominator());
+        assertEquals(1, b.add(c).getNumerator());
+        assertEquals(1, b.add(c).getDenominator());
     }
 
     @Test
-    public void negate() {
-        MixedFraction a = new MixedFraction(0, 1); // zero
-        MixedFraction b = new MixedFraction(1, 2); // positive
-        MixedFraction c = new MixedFraction(-2, 3); // negative
+    public void subtract() {
+        MixedFraction a = new MixedFraction(3, 2);
+        MixedFraction b = new MixedFraction(8, 3);
+        MixedFraction c = new MixedFraction(-5, 3);
 
-        assertEquals(0, a.negate().getNumerator());
-        assertEquals(1, a.negate().getDenominator());
-        assertEquals(-1, b.negate().getNumerator());
-        assertEquals(2, b.negate().getDenominator());
-        assertEquals(2, c.negate().getNumerator());
-        assertEquals(3, c.negate().getDenominator());
+        // null input
+        assertThrows(NullArgumentException.class, () -> a.subtract(null));
+
+        // valid input
+        assertEquals(-7, a.subtract(b).getNumerator());
+        assertEquals(6, a.subtract(b).getDenominator());
+        assertEquals(19, a.subtract(c).getNumerator());
+        assertEquals(6, a.subtract(c).getDenominator());
+        assertEquals(13, b.subtract(c).getNumerator());
+        assertEquals(3, b.subtract(c).getDenominator());
+    }
+
+    @Test
+    public void toString_validMixedFraction_returnsStringRepresentation() {
+        assertEquals("1/2", new MixedFraction(1, 2).toString());
+        assertEquals("1 2/3", new MixedFraction(5, 3).toString());
+        assertEquals("-1/2", new MixedFraction(-1, 2).toString());
+        assertEquals("-1 2/3", new MixedFraction(-5, 3).toString());
+        assertEquals("0", new MixedFraction(0, 1).toString());
     }
 }

--- a/src/test/java/seedu/address/model/ingredient/IngredientQuantityTest.java
+++ b/src/test/java/seedu/address/model/ingredient/IngredientQuantityTest.java
@@ -21,19 +21,29 @@ public class IngredientQuantityTest {
 
     @Test
     public void isValidIngredientQuantity() {
-        // null ingredient name
+        // null ingredient quantity
         assertThrows(NullPointerException.class, () -> IngredientQuantity.isValidIngredientQuantity(null));
 
-        // invalid ingredient name
+        // invalid ingredient quantity
         assertFalse(IngredientQuantity.isValidIngredientQuantity("")); // empty string
         assertFalse(IngredientQuantity.isValidIngredientQuantity(" ")); // spaces only
         assertFalse(IngredientQuantity.isValidIngredientQuantity("dozen")); // starts with alphabets
+        assertFalse(IngredientQuantity.isValidIngredientQuantity("1.")); // whole number with decimal point
+        assertFalse(IngredientQuantity.isValidIngredientQuantity("1 / 2 cups")); // spaces in fraction
+        assertFalse(IngredientQuantity.isValidIngredientQuantity("1 piece1")); // number in unit
 
-        // valid ingredient name
-        assertTrue(IngredientQuantity.isValidIngredientQuantity("12345")); // numbers only
-        assertTrue(IngredientQuantity.isValidIngredientQuantity("100 ml")); // alphanumeric characters
-        assertTrue(IngredientQuantity.isValidIngredientQuantity("2.5 cups")); // with decimal point
-        assertTrue(IngredientQuantity.isValidIngredientQuantity("2 1/2 cups")); // with fractions
+        // valid ingredient quantity
+        assertTrue(IngredientQuantity.isValidIngredientQuantity("12345")); // whole number
+        assertTrue(IngredientQuantity.isValidIngredientQuantity("0.5")); // decimal number
+        assertTrue(IngredientQuantity.isValidIngredientQuantity("1/2")); // pure fraction
+        assertTrue(IngredientQuantity.isValidIngredientQuantity("1 1/2")); // mixed fraction
+        assertTrue(IngredientQuantity.isValidIngredientQuantity("100 ml")); // whole number and unit
+        assertTrue(IngredientQuantity.isValidIngredientQuantity("100ml")); // no space between value and unit
+        assertTrue(IngredientQuantity.isValidIngredientQuantity("2.5 cups")); // decimal number and unit
+        assertTrue(IngredientQuantity.isValidIngredientQuantity(".5 cups")); // starts with decimal point
+        assertTrue(IngredientQuantity.isValidIngredientQuantity("1/2 cups")); // pure fractions and unit
+        assertTrue(IngredientQuantity.isValidIngredientQuantity("2 1/2 cups")); // mixed fractions and unit
         assertTrue(IngredientQuantity.isValidIngredientQuantity("1 Tablespoon")); // with capital letters
+        assertTrue(IngredientQuantity.isValidIngredientQuantity("1 rounded tsp")); // unit with spaces
     }
 }

--- a/src/test/java/seedu/address/model/ingredient/IngredientQuantityTest.java
+++ b/src/test/java/seedu/address/model/ingredient/IngredientQuantityTest.java
@@ -147,7 +147,7 @@ public class IngredientQuantityTest {
         assertEquals("2.5", IngredientQuantity.parseValue("2.5 cups").toString()); // decimal number and unit
         assertEquals("0.5", IngredientQuantity.parseValue(".5 cups").toString()); // starts with decimal point
         assertEquals("1/2", IngredientQuantity.parseValue("1/2 cups").toString()); // pure fractions and unit
-        assertEquals("2.6", IngredientQuantity.parseValue("2 3/5 cups").toString()); // denominator larger than 4
+        assertEquals("2.3", IngredientQuantity.parseValue("2 3/10 cups").toString()); // denominator larger than 6
         assertEquals("1", IngredientQuantity.parseValue("1 Tablespoon").toString()); // with capital letters
         assertEquals("1", IngredientQuantity.parseValue("1 rounded tsp").toString()); // unit with spaces;
     }
@@ -181,7 +181,7 @@ public class IngredientQuantityTest {
         assertEquals("2.5 cups", new IngredientQuantity("2.5 cups").toString()); // decimal number and unit
         assertEquals("0.5 cups", new IngredientQuantity(".5 cups").toString()); // starts with decimal point
         assertEquals("1/2 cups", new IngredientQuantity("1/2 cups").toString()); // pure fractions and unit
-        assertEquals("2.6 cups", new IngredientQuantity("2 3/5 cups").toString()); // mixed fractions and unit
+        assertEquals("2.3 cups", new IngredientQuantity("2 3/10 cups").toString()); // mixed fractions and unit
         assertEquals("1 Tablespoon", new IngredientQuantity("1 Tablespoon").toString()); // with capital letters
         assertEquals("1 rounded tsp", new IngredientQuantity("1 rounded tsp ").toString()); // unit with spaces;
     }

--- a/src/test/java/seedu/address/model/ingredient/IngredientQuantityTest.java
+++ b/src/test/java/seedu/address/model/ingredient/IngredientQuantityTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.ingredient;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -45,5 +46,92 @@ public class IngredientQuantityTest {
         assertTrue(IngredientQuantity.isValidIngredientQuantity("2 1/2 cups")); // mixed fractions and unit
         assertTrue(IngredientQuantity.isValidIngredientQuantity("1 Tablespoon")); // with capital letters
         assertTrue(IngredientQuantity.isValidIngredientQuantity("1 rounded tsp")); // unit with spaces
+    }
+
+    @Test
+    public void isCompatible() {
+        IngredientQuantity a = new IngredientQuantity("1 cup");
+        IngredientQuantity b = new IngredientQuantity("0.25 cup");
+        IngredientQuantity c = new IngredientQuantity("1/2 cup");
+        IngredientQuantity d = new IngredientQuantity("100 ml");
+
+        assertTrue(a.isCompatible(a));
+        assertTrue(a.isCompatible(b));
+        assertTrue(a.isCompatible(c));
+        assertTrue(b.isCompatible(a));
+        assertTrue(b.isCompatible(b));
+        assertTrue(b.isCompatible(c));
+        assertTrue(c.isCompatible(a));
+        assertTrue(c.isCompatible(b));
+        assertTrue(c.isCompatible(c));
+        assertTrue(d.isCompatible(d));
+        assertFalse(a.isCompatible(d));
+        assertFalse(b.isCompatible(d));
+        assertFalse(c.isCompatible(d));
+        assertFalse(d.isCompatible(a));
+        assertFalse(d.isCompatible(b));
+        assertFalse(d.isCompatible(c));
+    }
+
+    @Test
+    public void add() {
+        IngredientQuantity a = new IngredientQuantity("1 cup");
+        IngredientQuantity b = new IngredientQuantity("0.25 cup");
+        IngredientQuantity c = new IngredientQuantity("1/2 cup");
+        IngredientQuantity d = new IngredientQuantity("1.2cup");
+        IngredientQuantity e = new IngredientQuantity("100 ml");
+
+        assertThrows(IllegalArgumentException.class, () -> a.add(e));
+        assertThrows(IllegalArgumentException.class, () -> b.add(e));
+        assertThrows(IllegalArgumentException.class, () -> c.add(e));
+        assertThrows(IllegalArgumentException.class, () -> d.add(e));
+        assertThrows(IllegalArgumentException.class, () -> e.add(a));
+        assertThrows(IllegalArgumentException.class, () -> e.add(b));
+        assertThrows(IllegalArgumentException.class, () -> e.add(c));
+        assertThrows(IllegalArgumentException.class, () -> e.add(d));
+
+        assertEquals("1.25 cup", a.add(b).toString());
+        assertEquals("1 1/2 cup", a.add(c).toString());
+        assertEquals("2.2 cup", a.add(d).toString());
+        assertEquals("1.25 cup", b.add(a).toString());
+        assertEquals("3/4 cup", b.add(c).toString());
+        assertEquals("1.45 cup", b.add(d).toString());
+        assertEquals("1 1/2 cup", c.add(a).toString());
+        assertEquals("3/4 cup", c.add(b).toString());
+        assertEquals("1.7 cup", c.add(d).toString());
+        assertEquals("2.2 cup", d.add(a).toString());
+        assertEquals("1.45 cup", d.add(b).toString());
+        assertEquals("1.7 cup", d.add(c).toString());
+    }
+
+    @Test
+    public void subtract() {
+        IngredientQuantity a = new IngredientQuantity("1 cup");
+        IngredientQuantity b = new IngredientQuantity("0.25 cup");
+        IngredientQuantity c = new IngredientQuantity("1/2 cup");
+        IngredientQuantity d = new IngredientQuantity("1.2cup");
+        IngredientQuantity e = new IngredientQuantity("100 ml");
+
+        assertThrows(IllegalArgumentException.class, () -> a.subtract(e));
+        assertThrows(IllegalArgumentException.class, () -> b.subtract(e));
+        assertThrows(IllegalArgumentException.class, () -> c.subtract(e));
+        assertThrows(IllegalArgumentException.class, () -> d.subtract(e));
+        assertThrows(IllegalArgumentException.class, () -> e.subtract(a));
+        assertThrows(IllegalArgumentException.class, () -> e.subtract(b));
+        assertThrows(IllegalArgumentException.class, () -> e.subtract(c));
+        assertThrows(IllegalArgumentException.class, () -> e.subtract(d));
+
+        assertEquals("0.75 cup", a.subtract(b).toString());
+        assertEquals("1/2 cup", a.subtract(c).toString());
+        assertEquals("0 cup", a.subtract(d).toString());
+        assertEquals("0 cup", b.subtract(a).toString());
+        assertEquals("0 cup", b.subtract(c).toString());
+        assertEquals("0 cup", b.subtract(d).toString());
+        assertEquals("0 cup", c.subtract(a).toString());
+        assertEquals("1/4 cup", c.subtract(b).toString());
+        assertEquals("0 cup", c.subtract(d).toString());
+        assertEquals("0.2 cup", d.subtract(a).toString());
+        assertEquals("0.95 cup", d.subtract(b).toString());
+        assertEquals("0.7 cup", d.subtract(c).toString());
     }
 }

--- a/src/test/java/seedu/address/model/ingredient/IngredientQuantityTest.java
+++ b/src/test/java/seedu/address/model/ingredient/IngredientQuantityTest.java
@@ -49,35 +49,35 @@ public class IngredientQuantityTest {
     }
 
     @Test
-    public void isCompatible() {
+    public void isCompatibleWith() {
         IngredientQuantity a = new IngredientQuantity("1 cup");
         IngredientQuantity b = new IngredientQuantity("0.25 cup");
         IngredientQuantity c = new IngredientQuantity("1/2 cup");
         IngredientQuantity d = new IngredientQuantity("100 ml");
 
-        assertTrue(a.isCompatible(a));
-        assertTrue(a.isCompatible(b));
-        assertTrue(a.isCompatible(c));
-        assertTrue(b.isCompatible(a));
-        assertTrue(b.isCompatible(b));
-        assertTrue(b.isCompatible(c));
-        assertTrue(c.isCompatible(a));
-        assertTrue(c.isCompatible(b));
-        assertTrue(c.isCompatible(c));
-        assertTrue(d.isCompatible(d));
-        assertFalse(a.isCompatible(d));
-        assertFalse(b.isCompatible(d));
-        assertFalse(c.isCompatible(d));
-        assertFalse(d.isCompatible(a));
-        assertFalse(d.isCompatible(b));
-        assertFalse(d.isCompatible(c));
+        assertTrue(a.isCompatibleWith(a));
+        assertTrue(a.isCompatibleWith(b));
+        assertTrue(a.isCompatibleWith(c));
+        assertTrue(b.isCompatibleWith(a));
+        assertTrue(b.isCompatibleWith(b));
+        assertTrue(b.isCompatibleWith(c));
+        assertTrue(c.isCompatibleWith(a));
+        assertTrue(c.isCompatibleWith(b));
+        assertTrue(c.isCompatibleWith(c));
+        assertTrue(d.isCompatibleWith(d));
+        assertFalse(a.isCompatibleWith(d));
+        assertFalse(b.isCompatibleWith(d));
+        assertFalse(c.isCompatibleWith(d));
+        assertFalse(d.isCompatibleWith(a));
+        assertFalse(d.isCompatibleWith(b));
+        assertFalse(d.isCompatibleWith(c));
     }
 
     @Test
     public void add() {
         IngredientQuantity a = new IngredientQuantity("1 cup");
         IngredientQuantity b = new IngredientQuantity("0.25 cup");
-        IngredientQuantity c = new IngredientQuantity("1/2 cup");
+        IngredientQuantity c = new IngredientQuantity("2 1/2 cup");
         IngredientQuantity d = new IngredientQuantity("1.2cup");
         IngredientQuantity e = new IngredientQuantity("100 ml");
 
@@ -91,17 +91,17 @@ public class IngredientQuantityTest {
         assertThrows(IllegalArgumentException.class, () -> e.add(d));
 
         assertEquals("1.25 cup", a.add(b).toString());
-        assertEquals("1 1/2 cup", a.add(c).toString());
+        assertEquals("3 1/2 cup", a.add(c).toString());
         assertEquals("2.2 cup", a.add(d).toString());
         assertEquals("1.25 cup", b.add(a).toString());
-        assertEquals("3/4 cup", b.add(c).toString());
+        assertEquals("2 3/4 cup", b.add(c).toString());
         assertEquals("1.45 cup", b.add(d).toString());
-        assertEquals("1 1/2 cup", c.add(a).toString());
-        assertEquals("3/4 cup", c.add(b).toString());
-        assertEquals("1.7 cup", c.add(d).toString());
+        assertEquals("3 1/2 cup", c.add(a).toString());
+        assertEquals("2 3/4 cup", c.add(b).toString());
+        assertEquals("3.7 cup", c.add(d).toString());
         assertEquals("2.2 cup", d.add(a).toString());
         assertEquals("1.45 cup", d.add(b).toString());
-        assertEquals("1.7 cup", d.add(c).toString());
+        assertEquals("3.7 cup", d.add(c).toString());
     }
 
     @Test
@@ -133,5 +133,56 @@ public class IngredientQuantityTest {
         assertEquals("0.2 cup", d.subtract(a).toString());
         assertEquals("0.95 cup", d.subtract(b).toString());
         assertEquals("0.7 cup", d.subtract(c).toString());
+    }
+
+    @Test
+    public void parseValue() {
+        // valid ingredient quantity
+        assertEquals("12345", IngredientQuantity.parseValue("12345").toString()); // whole number
+        assertEquals("0.5", IngredientQuantity.parseValue("0.5").toString()); // decimal number
+        assertEquals("1/2", IngredientQuantity.parseValue("1/2").toString()); // pure fraction
+        assertEquals("1 1/2", IngredientQuantity.parseValue("1 1/2").toString()); // mixed fraction
+        assertEquals("100", IngredientQuantity.parseValue("100 ml").toString()); // whole number and unit
+        assertEquals("100", IngredientQuantity.parseValue("100ml").toString()); // no space between value and unit
+        assertEquals("2.5", IngredientQuantity.parseValue("2.5 cups").toString()); // decimal number and unit
+        assertEquals("0.5", IngredientQuantity.parseValue(".5 cups").toString()); // starts with decimal point
+        assertEquals("1/2", IngredientQuantity.parseValue("1/2 cups").toString()); // pure fractions and unit
+        assertEquals("2.6", IngredientQuantity.parseValue("2 3/5 cups").toString()); // denominator larger than 4
+        assertEquals("1", IngredientQuantity.parseValue("1 Tablespoon").toString()); // with capital letters
+        assertEquals("1", IngredientQuantity.parseValue("1 rounded tsp").toString()); // unit with spaces;
+    }
+
+    @Test
+    public void parseUnit() {
+        // valid ingredient quantity
+        assertEquals("", IngredientQuantity.parseUnit("12345")); // whole number
+        assertEquals("", IngredientQuantity.parseUnit("0.5")); // decimal number
+        assertEquals("", IngredientQuantity.parseUnit("1/2")); // pure fraction
+        assertEquals("", IngredientQuantity.parseUnit("1 1/2")); // mixed fraction
+        assertEquals("ml", IngredientQuantity.parseUnit("100 ml")); // whole number and unit
+        assertEquals("ml", IngredientQuantity.parseUnit("100ml")); // no space between value and unit
+        assertEquals("cups", IngredientQuantity.parseUnit("2.5 cups")); // decimal number and unit
+        assertEquals("cups", IngredientQuantity.parseUnit(".5 cups")); // starts with decimal point
+        assertEquals("cups", IngredientQuantity.parseUnit("1/2 cups")); // pure fractions and unit
+        assertEquals("cups", IngredientQuantity.parseUnit("2 3/5 cups")); // mixed fractions and unit
+        assertEquals("Tablespoon", IngredientQuantity.parseUnit("1 Tablespoon")); // with capital letters
+        assertEquals("rounded tsp", IngredientQuantity.parseUnit("1 rounded tsp ")); // unit with spaces;
+    }
+
+    @Test
+    public void toString_validIngredientQuantity_returnsStringRepresentation() {
+        // valid ingredient quantity
+        assertEquals("12345", new IngredientQuantity("12345").toString()); // whole number
+        assertEquals("0.5", new IngredientQuantity("0.5").toString()); // decimal number
+        assertEquals("1/2", new IngredientQuantity("1/2").toString()); // pure fraction
+        assertEquals("1 1/2", new IngredientQuantity("1 1/2").toString()); // mixed fraction
+        assertEquals("100 ml", new IngredientQuantity("100 ml").toString()); // whole number and unit
+        assertEquals("100 ml", new IngredientQuantity("100ml").toString()); // no space between value and unit
+        assertEquals("2.5 cups", new IngredientQuantity("2.5 cups").toString()); // decimal number and unit
+        assertEquals("0.5 cups", new IngredientQuantity(".5 cups").toString()); // starts with decimal point
+        assertEquals("1/2 cups", new IngredientQuantity("1/2 cups").toString()); // pure fractions and unit
+        assertEquals("2.6 cups", new IngredientQuantity("2 3/5 cups").toString()); // mixed fractions and unit
+        assertEquals("1 Tablespoon", new IngredientQuantity("1 Tablespoon").toString()); // with capital letters
+        assertEquals("1 rounded tsp", new IngredientQuantity("1 rounded tsp ").toString()); // unit with spaces;
     }
 }


### PR DESCRIPTION
**tldr: For 2 ingredient quantities `a` and `b`, you can now execute `a.isCompatibleWith(b)` to check if they can be added/subtracted, then do `a.add(b)` or `a.subtract(b)`.**

Add Apache Commons Math 3.6.2 to gradle dependencies.

Add a new class `MixedFraction` to `seedu.address.commons.core.fraction`, which inherits from `Fraction` in Apache Commons Math.

Add parsing of ingredient quantity into a value and an optional unit.

Implement value as `BigDecimal` or `MixedFraction`. (`BigDecimal` is chosen to avoid floating point errors)

Store unit as a `String`.

Add support for addition and subtraction if the units are the same, and if the subtraction results in a negative value, return an `IngredientQuantity` with a value of 0.

Cap maximum denominator of fractions at 6, to avoid unusual fractions.

Add tests for `MixedFraction` and `IngredientQuantity`.