### PR TITLE
Construct skeletal structure for CookingPapa commands

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_RECIPE_DISPLAYED_INDEX = "The recipe index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 
 }

--- a/src/main/java/seedu/address/logic/commands/cookbook/CookbookCommand.java
+++ b/src/main/java/seedu/address/logic/commands/cookbook/CookbookCommand.java
@@ -1,0 +1,12 @@
+package seedu.address.logic.commands.cookbook;
+
+import seedu.address.logic.commands.Command;
+
+/**
+ * Represents a cookbook command with hidden internal logic and the ability to be executed.
+ */
+public abstract class CookbookCommand extends Command {
+
+    public static final String COMMAND_CATEGORY = "cookbook";
+
+}

--- a/src/main/java/seedu/address/logic/commands/inventory/InventoryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/inventory/InventoryCommand.java
@@ -1,0 +1,12 @@
+package seedu.address.logic.commands.inventory;
+
+import seedu.address.logic.commands.Command;
+
+/**
+ * Represents an inventory command with hidden internal logic and the ability to be executed.
+ */
+public abstract class InventoryCommand extends Command {
+
+    public static final String COMMAND_CATEGORY = "inventory";
+
+}

--- a/src/main/java/seedu/address/logic/commands/recipe/EditRecipeDescriptor.java
+++ b/src/main/java/seedu/address/logic/commands/recipe/EditRecipeDescriptor.java
@@ -1,0 +1,139 @@
+package seedu.address.logic.commands.recipe;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.model.ingredient.UniqueIngredientList;
+import seedu.address.model.recipe.Recipe;
+import seedu.address.model.recipe.RecipeDescription;
+import seedu.address.model.recipe.RecipeName;
+import seedu.address.model.step.UniqueStepList;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Stores the details to edit the recipe with. Each non-empty field value will replace the
+ * corresponding field value of the recipe.
+ */
+public class EditRecipeDescriptor {
+    private RecipeName name;
+    private RecipeDescription description;
+    private UniqueIngredientList ingredients;
+    private UniqueStepList steps;
+    private Set<Tag> tags;
+
+    public EditRecipeDescriptor() {}
+
+    /**
+     * Copy constructor.
+     * A defensive copy of {@code tags} is used internally.
+     */
+    public EditRecipeDescriptor(EditRecipeDescriptor toCopy) {
+        setName(toCopy.name);
+        setDescription(toCopy.description);
+        setIngredients(toCopy.ingredients);
+        setSteps(toCopy.steps);
+        setTags(toCopy.tags);
+    }
+
+    /**
+     * Creates and returns a {@code Recipe} with the details of {@code recipeToEdit}
+     * edited with {@code editRecipeDescriptor}.
+     */
+    public static Recipe createEditedRecipe(Recipe recipeToEdit, EditRecipeDescriptor editRecipeDescriptor) {
+        assert recipeToEdit != null;
+
+        RecipeName updatedName = editRecipeDescriptor.getName()
+                .orElse(recipeToEdit.getName());
+        RecipeDescription updatedDescription = editRecipeDescriptor.getDescription()
+                .orElse(recipeToEdit.getDescription());
+        UniqueIngredientList updatedIngredients = editRecipeDescriptor.getIngredients()
+                .orElse(recipeToEdit.getIngredients());
+        UniqueStepList updatedSteps = editRecipeDescriptor.getSteps()
+                .orElse(recipeToEdit.getSteps());
+        Set<Tag> updatedTags = editRecipeDescriptor.getTags()
+                .orElse(recipeToEdit.getTags());
+
+        return new Recipe(updatedName, updatedDescription, updatedIngredients, updatedSteps, updatedTags);
+    }
+
+    /**
+     * Returns true if at least one field is edited.
+     */
+    public boolean isAnyFieldEdited() {
+        return CollectionUtil.isAnyNonNull(name, description, ingredients, steps, tags);
+    }
+
+    public void setName(RecipeName name) {
+        this.name = name;
+    }
+
+    public Optional<RecipeName> getName() {
+        return Optional.ofNullable(name);
+    }
+
+    public void setDescription(RecipeDescription description) {
+        this.description = description;
+    }
+
+    public Optional<RecipeDescription> getDescription() {
+        return Optional.ofNullable(description);
+    }
+
+    public void setIngredients(UniqueIngredientList ingredients) {
+        this.ingredients = ingredients;
+    }
+
+    public Optional<UniqueIngredientList> getIngredients() {
+        return Optional.ofNullable(ingredients);
+    }
+
+    public void setSteps(UniqueStepList steps) {
+        this.steps = steps;
+    }
+
+    public Optional<UniqueStepList> getSteps() {
+        return Optional.ofNullable(steps);
+    }
+
+    /**
+     * Sets {@code tags} to this object's {@code tags}.
+     * A defensive copy of {@code tags} is used internally.
+     */
+    public void setTags(Set<Tag> tags) {
+        this.tags = (tags != null) ? new HashSet<>(tags) : null;
+    }
+
+    /**
+     * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException}
+     * if modification is attempted.
+     * Returns {@code Optional#empty()} if {@code tags} is null.
+     */
+    public Optional<Set<Tag>> getTags() {
+        return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditRecipeDescriptor)) {
+            return false;
+        }
+
+        // state check
+        EditRecipeDescriptor e = (EditRecipeDescriptor) other;
+
+        return getName().equals(e.getName())
+                && getDescription().equals(e.getDescription())
+                && getIngredients().equals(e.getIngredients())
+                && getSteps().equals(e.getSteps())
+                && getTags().equals(e.getTags());
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/recipe/RecipeAddIngredientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/recipe/RecipeAddIngredientCommand.java
@@ -1,0 +1,84 @@
+package seedu.address.logic.commands.recipe;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INGREDIENT_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INGREDIENT_QUANTITY;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_RECIPES;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ingredient.Ingredient;
+import seedu.address.model.ingredient.UniqueIngredientList;
+import seedu.address.model.recipe.Recipe;
+
+/**
+ * Adds a person to the address book.
+ */
+public class RecipeAddIngredientCommand extends RecipeCommand {
+
+    public static final String COMMAND_WORD = "add";
+    public static final String COMMAND_TYPE = "ingredient";
+
+    public static final String MESSAGE_USAGE = COMMAND_CATEGORY + " " + COMMAND_WORD + " " + COMMAND_TYPE
+            + ": Adds an ingredient to a recipe. "
+            + "Parameters: "
+            + "INDEX (must be a positive integer)"
+            + PREFIX_INGREDIENT_NAME + "INGREDIENT "
+            + PREFIX_INGREDIENT_QUANTITY + "QUANTITY\n"
+            + "Example: " + COMMAND_CATEGORY + " 1 "
+            + COMMAND_WORD + " "
+            + PREFIX_INGREDIENT_NAME + "Eggs "
+            + PREFIX_INGREDIENT_QUANTITY + "12";
+
+    public static final String MESSAGE_SUCCESS = "New ingredient added: %1$s";
+    public static final String MESSAGE_INCOMPATIBLE_UNITS = "This ingredient has different units "
+            + "from the same ingredient in the recipe";
+
+    private final Index index;
+    private final Ingredient toAdd;
+
+    /**
+     * Creates a RecipeAddIngredientCommand to add the specified {@code Ingredient} to the recipe
+     */
+    public RecipeAddIngredientCommand(Index index, Ingredient toAdd) {
+        requireNonNull(index);
+        requireNonNull(toAdd);
+        this.index = index;
+        this.toAdd = toAdd;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Recipe> lastShownList = model.getFilteredRecipeList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_RECIPE_DISPLAYED_INDEX);
+        }
+
+        Recipe recipeToEdit = lastShownList.get(index.getZeroBased());
+        UniqueIngredientList ingredients = recipeToEdit.getIngredients();
+        ingredients.add(toAdd);
+
+        EditRecipeDescriptor editRecipeDescriptor = new EditRecipeDescriptor();
+        editRecipeDescriptor.setIngredients(ingredients);
+        Recipe editedRecipe = EditRecipeDescriptor.createEditedRecipe(recipeToEdit, editRecipeDescriptor);
+
+        model.setRecipe(recipeToEdit, editedRecipe);
+        model.updateFilteredRecipeList(PREDICATE_SHOW_ALL_RECIPES);
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof RecipeAddIngredientCommand // instanceof handles nulls
+                && toAdd.equals(((RecipeAddIngredientCommand) other).toAdd));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/recipe/RecipeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/recipe/RecipeCommand.java
@@ -1,0 +1,12 @@
+package seedu.address.logic.commands.recipe;
+
+import seedu.address.logic.commands.Command;
+
+/**
+ * Represents a recipe command with hidden internal logic and the ability to be executed.
+ */
+public abstract class RecipeCommand extends Command {
+
+    public static final String COMMAND_CATEGORY = "recipe";
+
+}

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -7,6 +7,11 @@ public class CliSyntax {
 
     /* Prefix definitions */
     public static final Prefix PREFIX_NAME = new Prefix("n/");
+    public static final Prefix PREFIX_DESCRIPTION = new Prefix("d/");
+    public static final Prefix PREFIX_INGREDIENT_NAME = new Prefix("i/");
+    public static final Prefix PREFIX_INGREDIENT_QUANTITY = new Prefix("q/");
+    public static final Prefix PREFIX_STEP_INDEX = new Prefix("x/");
+    public static final Prefix PREFIX_STEP_DESCRIPTION = new Prefix("s/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/CookingPapaParser.java
+++ b/src/main/java/seedu/address/logic/parser/CookingPapaParser.java
@@ -1,0 +1,59 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.cookbook.CookbookCommand;
+import seedu.address.logic.commands.inventory.InventoryCommand;
+import seedu.address.logic.commands.recipe.RecipeCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses user input.
+ */
+public class CookingPapaParser {
+
+    /**
+     * Used for initial separation of command word and args.
+     */
+    private static final Pattern BASIC_COMMAND_FORMAT = Pattern
+            .compile("(?<commandCategory>\\S+)(?<index>\\S+)?(?<commandWord>\\S+)?(?<arguments>.*)");
+
+    /**
+     * Parses user input into command for execution.
+     *
+     * @param userInput full user input string
+     * @return the command based on the user input
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public Command parseCommand(String userInput) throws ParseException {
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+        if (!matcher.matches()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        }
+
+        final String commandCategory = matcher.group("commandCategory");
+        final String commandWord = matcher.group("commandWord");
+        final String arguments = matcher.group("arguments");
+        switch (commandCategory) {
+
+        case CookbookCommand.COMMAND_CATEGORY:
+            return null;
+
+        case RecipeCommand.COMMAND_CATEGORY:
+            return null;
+
+        case InventoryCommand.COMMAND_CATEGORY:
+            return null;
+
+        default:
+            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.Person;
+import seedu.address.model.recipe.Recipe;
 
 /**
  * The API of the Model component.
@@ -13,6 +14,9 @@ import seedu.address.model.person.Person;
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
+
+    /** {@code Predicate} that always evaluate to true */
+    Predicate<Recipe> PREDICATE_SHOW_ALL_RECIPES = unused -> true;
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
@@ -58,6 +62,11 @@ public interface Model {
     boolean hasPerson(Person person);
 
     /**
+     * Returns true if a recipe with the same identity as {@code recipe} exists in the cookbook.
+     */
+    boolean hasRecipe(Recipe recipe);
+
+    /**
      * Deletes the given person.
      * The person must exist in the address book.
      */
@@ -70,18 +79,40 @@ public interface Model {
     void addPerson(Person person);
 
     /**
+     * Adds the given recipe.
+     * {@code person} must not already exist in the cookbook.
+     */
+    void addRecipe(Recipe recipe);
+
+    /**
      * Replaces the given person {@code target} with {@code editedPerson}.
      * {@code target} must exist in the address book.
      * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
      */
     void setPerson(Person target, Person editedPerson);
 
+    /**
+     * Replaces the given recipe {@code target} with {@code editedRecipe}.
+     * {@code target} must exist in the cookbook.
+     * The recipe identity of {@code editedRecipe} must not be the same as another existing recipe in the cookbook.
+     */
+    void setRecipe(Recipe target, Recipe editedRecipe);
+
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
+
+    /** Returns an unmodifiable view of the filtered person list */
+    ObservableList<Recipe> getFilteredRecipeList();
 
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Updates the filter of the filtered recipe list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredRecipeList(Predicate<Recipe> predicate);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -12,6 +12,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
+import seedu.address.model.recipe.Recipe;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -95,6 +96,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasRecipe(Recipe recipe) {
+        // TODO: implement
+        return false;
+    }
+
+    @Override
     public void deletePerson(Person target) {
         addressBook.removePerson(target);
     }
@@ -106,10 +113,22 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void addRecipe(Recipe recipe) {
+        // TODO: implement
+        return;
+    }
+
+    @Override
     public void setPerson(Person target, Person editedPerson) {
         requireAllNonNull(target, editedPerson);
 
         addressBook.setPerson(target, editedPerson);
+    }
+
+    @Override
+    public void setRecipe(Recipe target, Recipe editedRecipe) {
+        // TODO: implement
+        return;
     }
 
     //=========== Filtered Person List Accessors =============================================================
@@ -124,9 +143,21 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public ObservableList<Recipe> getFilteredRecipeList() {
+        // TODO: implement
+        return null;
+    }
+
+    @Override
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+
+    @Override
+    public void updateFilteredRecipeList(Predicate<Recipe> predicate) {
+        // TODO: implement
+        return;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -83,8 +83,7 @@ public class Person {
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
-        builder.append(getName())
-                .append(" Tags: ");
+        builder.append(getName()).append(" Tags: ");
         getTags().forEach(builder::append);
         return builder.toString();
     }

--- a/src/main/java/seedu/address/model/recipe/Recipe.java
+++ b/src/main/java/seedu/address/model/recipe/Recipe.java
@@ -19,11 +19,11 @@ public class Recipe {
 
     // Identity fields
     private final RecipeName name;
-    private final RecipeDescription description;
 
     // Data fields
-    private final UniqueIngredientList ingredients = new UniqueIngredientList();
-    private final UniqueStepList steps = new UniqueStepList();
+    private final RecipeDescription description;
+    private final UniqueIngredientList ingredients;
+    private final UniqueStepList steps;
     private final Set<Tag> tags = new HashSet<>();
 
     /**
@@ -34,21 +34,23 @@ public class Recipe {
         requireAllNonNull(name, description);
         this.name = name;
         this.description = description;
+        this.ingredients = new UniqueIngredientList();
+        this.steps = new UniqueStepList();
     }
 
     /**
      * Recipe constructor for optional fields
      * Every field must be present and not null.
      */
-    //public Recipe(RecipeName name, RecipeDescription description,
-    //  IngredientList ingredients, StepList steps, Set<Tag> tags) {
-    //    requireAllNonNull(name, description, ingredients, steps, tags);
-    //    this.name = name;
-    //    this.description = description;
-    //    this.ingredients = ingredients;
-    //    this.steps = steps;
-    //    this.tags.addAll(tags);
-    //}
+    public Recipe(RecipeName name, RecipeDescription description,
+            UniqueIngredientList ingredients, UniqueStepList steps, Set<Tag> tags) {
+        requireAllNonNull(name, description, ingredients, steps, tags);
+        this.name = name;
+        this.description = description;
+        this.ingredients = ingredients;
+        this.steps = steps;
+        this.tags.addAll(tags);
+    }
 
     public RecipeName getName() {
         return name;
@@ -75,7 +77,7 @@ public class Recipe {
     }
 
     /**
-     * Returns true if both recipes of the same name have descriptions that are the same.
+     * Returns true if both recipes have the same name.
      * This defines a weaker notion of equality between two recipes.
      */
     public boolean isSameRecipe(Recipe otherRecipe) {
@@ -84,8 +86,7 @@ public class Recipe {
         }
 
         return otherRecipe != null
-                && otherRecipe.getName().equals(getName())
-                && otherRecipe.getDescription().equals(getDescription());
+                && otherRecipe.getName().equals(getName());
     }
 
     /**

--- a/src/main/java/seedu/address/model/recipe/UniqueRecipeList.java
+++ b/src/main/java/seedu/address/model/recipe/UniqueRecipeList.java
@@ -1,0 +1,21 @@
+package seedu.address.model.recipe;
+
+import java.util.Iterator;
+
+/**
+ * A list of recipes that enforces uniqueness between its elements and does not allow nulls.
+ * A recipe is considered unique by comparing using {@code Recipe#isSameRecipe(Recipe)}. As such, adding and updating of
+ * recipes uses Recipe#isSameRecipe(Recipe) for equality so as to ensure that the recipe being added or updated is
+ * unique in terms of identity in the UniqueRecipeList. However, the removal of a recipe uses Recipe#equals(Object) so
+ * as to ensure that the recipe with exactly the same fields will be removed.
+ *
+ * Supports a minimal set of list operations.
+ *
+ * @see Recipe#isSameRecipe(Recipe)
+ */
+public class UniqueRecipeList implements Iterable<Recipe> {
+    @Override
+    public Iterator<Recipe> iterator() {
+        return null;
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -21,6 +21,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.person.Person;
+import seedu.address.model.recipe.Recipe;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddCommandTest {
@@ -114,6 +115,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void addRecipe(Recipe person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setAddressBook(ReadOnlyAddressBook newData) {
             throw new AssertionError("This method should not be called.");
         }
@@ -129,6 +135,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean hasRecipe(Recipe person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void deletePerson(Person target) {
             throw new AssertionError("This method should not be called.");
         }
@@ -139,12 +150,27 @@ public class AddCommandTest {
         }
 
         @Override
+        public void setRecipe(Recipe target, Recipe editedPerson) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
+        public ObservableList<Recipe> getFilteredRecipeList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredRecipeList(Predicate<Recipe> predicate) {
             throw new AssertionError("This method should not be called.");
         }
     }


### PR DESCRIPTION
Changes:
- Create new subpackages for each category of commands (cookbook, recipe, etc)
- Add `RecipeAddIngredientCommand`
- Modify the command's dependencies, including adding `UniqueRecipeList` and `EditRecipeDescriptor`, and changing `Model` and `ModelManager`
- Add a basic `CookingPapaParser`, based on `AddressBookParser`

Other notes:
- Tests have not been written
- To get the commands to work, we should implement the command parsers (eg. `AddCommandParser`). Only a minimal implementation of the commands themselves (eg. `AddCommand`) are required.