### PR TITLE
Implement removal of all of an ingredient when quantity is not specified

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -224,7 +224,7 @@ This command allows you to add ingredients to a recipe.
 You can remove ingredients that spoil the taste of the dish using this command.
 If the quantity to be removed is not specified, all of the ingredient will be removed.
 
-- Format: `recipe INDEX remove ingredient i/INGREDIENT q/QUANTITY`
+- Format: `recipe INDEX remove ingredient i/INGREDIENT [q/QUANTITY]`
 - Examples:
 |===
 | Parameters | Result
@@ -334,7 +334,7 @@ This command allows you to remove ingredients from your inventory. You may add i
 an additional argument for the quantity you wish to remove. If no additional argument for quantity
 is supplied, that instance of the ingredient will be removed entirely.
 
-- Format: `inventory remove ingredient i/INGREDIENT q/QUANTITY`
+- Format: `inventory remove ingredient i/INGREDIENT [q/QUANTITY]`
 - Examples:
 |===
 | Parameters | Result
@@ -342,8 +342,8 @@ is supplied, that instance of the ingredient will be removed entirely.
 |`inventory remove ingredient i/Egg q/10`
 |Removes 10 eggs into your inventory.
 
-|`inventory remove ingredient i/Butter q/200g`
-|Removes 200g of butter into your inventory.
+|`inventory remove ingredient i/Butter`
+|Removes all butter into your inventory.
 |===
 
 [[Cart]]
@@ -380,15 +380,15 @@ This command allows you to add ingredients to the cart.
 This command allows you to remove ingredients from the cart.
 If the quantity to be removed is not specified, all of the specified ingredient will be removed.
 
-- Format: `cart remove ingredient i/INGREDIENT q/QUANTITY`
+- Format: `cart remove ingredient i/INGREDIENT [q/QUANTITY]`
 - Example:
 |===
 | Parameters | Result
 
 |`cart remove ingredient i/Egg q/1`
 |Removes 1 egg from the cart
-|`cart remove i/Milk q/200ml`
-|Removes 200ml of milk from the cart.
+|`cart remove i/Milk`
+|Removes all milk from the cart.
 |===
 
 ==== Clear all the items in the cart

--- a/src/main/java/seedu/address/logic/parser/cart/CartRemoveIngredientCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/cart/CartRemoveIngredientCommandParser.java
@@ -41,8 +41,9 @@ public class CartRemoveIngredientCommandParser implements Parser<CartCommand> {
 
         IngredientName ingredientName = ParserUtil.parseIngredientName(argMultimap
                 .getValue(PREFIX_INGREDIENT_NAME).get());
-        IngredientQuantity ingredientQuantity = ParserUtil.parseIngredientQuantity(argMultimap
-                .getValue(PREFIX_INGREDIENT_QUANTITY).get());
+        IngredientQuantity ingredientQuantity = argMultimap.arePrefixesPresent(PREFIX_INGREDIENT_QUANTITY)
+                ? ParserUtil.parseIngredientQuantity(argMultimap.getValue(PREFIX_INGREDIENT_QUANTITY).get())
+                : IngredientQuantity.getDummyQuantity();
 
         Ingredient ingredient = new Ingredient(ingredientName, ingredientQuantity);
 

--- a/src/main/java/seedu/address/logic/parser/inventory/InventoryRemoveIngredientCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/inventory/InventoryRemoveIngredientCommandParser.java
@@ -33,7 +33,7 @@ public class InventoryRemoveIngredientCommandParser implements Parser<InventoryC
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_INGREDIENT_NAME, PREFIX_INGREDIENT_QUANTITY);
 
-        if (!argMultimap.arePrefixesPresent(PREFIX_INGREDIENT_NAME, PREFIX_INGREDIENT_QUANTITY)
+        if (!argMultimap.arePrefixesPresent(PREFIX_INGREDIENT_NAME)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     InventoryRemoveIngredientCommand.MESSAGE_USAGE));
@@ -41,9 +41,9 @@ public class InventoryRemoveIngredientCommandParser implements Parser<InventoryC
 
         IngredientName ingredientName = ParserUtil.parseIngredientName(argMultimap
                 .getValue(PREFIX_INGREDIENT_NAME).get());
-
-        IngredientQuantity ingredientQuantity = ParserUtil.parseIngredientQuantity(argMultimap
-                .getValue(PREFIX_INGREDIENT_QUANTITY).get());
+        IngredientQuantity ingredientQuantity = argMultimap.arePrefixesPresent(PREFIX_INGREDIENT_QUANTITY)
+                ? ParserUtil.parseIngredientQuantity(argMultimap.getValue(PREFIX_INGREDIENT_QUANTITY).get())
+                : IngredientQuantity.getDummyQuantity();
 
         Ingredient ingredient = new Ingredient(ingredientName, ingredientQuantity);
 

--- a/src/main/java/seedu/address/logic/parser/inventory/InventoryRemoveIngredientCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/inventory/InventoryRemoveIngredientCommandParser.java
@@ -33,7 +33,7 @@ public class InventoryRemoveIngredientCommandParser implements Parser<InventoryC
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_INGREDIENT_NAME, PREFIX_INGREDIENT_QUANTITY);
 
-        if (!argMultimap.arePrefixesPresent(PREFIX_INGREDIENT_NAME)
+        if (!argMultimap.arePrefixesPresent(PREFIX_INGREDIENT_NAME, PREFIX_INGREDIENT_QUANTITY)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     InventoryRemoveIngredientCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/recipe/RecipeRemoveCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/recipe/RecipeRemoveCommandParser.java
@@ -87,8 +87,9 @@ public class RecipeRemoveCommandParser implements Parser<RecipeRemoveCommand> {
 
         IngredientName ingredientName = ParserUtil.parseIngredientName(argMultimap
                 .getValue(PREFIX_INGREDIENT_NAME).get());
-        IngredientQuantity ingredientQuantity = ParserUtil.parseIngredientQuantity(argMultimap
-                .getValue(PREFIX_INGREDIENT_QUANTITY).get());
+        IngredientQuantity ingredientQuantity = argMultimap.arePrefixesPresent(PREFIX_INGREDIENT_QUANTITY)
+                ? ParserUtil.parseIngredientQuantity(argMultimap.getValue(PREFIX_INGREDIENT_QUANTITY).get())
+                : IngredientQuantity.getDummyQuantity();
 
         Ingredient ingredient = new Ingredient(ingredientName, ingredientQuantity);
 

--- a/src/main/java/seedu/address/model/ingredient/IngredientQuantity.java
+++ b/src/main/java/seedu/address/model/ingredient/IngredientQuantity.java
@@ -59,6 +59,10 @@ public class IngredientQuantity {
         this.unit = unit;
     }
 
+    public static IngredientQuantity getDummyQuantity() {
+        return new DummyIngredientQuantity();
+    }
+
     /**
      * Returns true if a given string is a valid ingredient quantity.
      */
@@ -70,6 +74,9 @@ public class IngredientQuantity {
      * Returns true if the specified ingredient quantity has the same unit as the ingredient quantity.
      */
     public boolean hasSameUnitAs(IngredientQuantity other) {
+        if (other instanceof DummyIngredientQuantity) {
+            return true;
+        }
         return this.unit.equals(other.unit);
     }
 
@@ -81,6 +88,9 @@ public class IngredientQuantity {
      */
     public IngredientQuantity add(IngredientQuantity other) {
         checkArgument(hasSameUnitAs(other));
+        if (other instanceof DummyIngredientQuantity) {
+            return this;
+        }
 
         Number newValue = null;
         if (this.value instanceof BigDecimal && other.value instanceof BigDecimal) {
@@ -113,6 +123,9 @@ public class IngredientQuantity {
      */
     public IngredientQuantity subtract(IngredientQuantity other) {
         checkArgument(hasSameUnitAs(other));
+        if (other instanceof DummyIngredientQuantity) {
+            throw new NonPositiveIngredientQuantityException();
+        }
 
         Number newValue = null;
         if (this.value instanceof BigDecimal && other.value instanceof BigDecimal) {
@@ -204,4 +217,41 @@ public class IngredientQuantity {
         return Objects.hash(value, unit);
     }
 
+    /**
+     * Represents a dummy {@code IngredientQuantity}.
+     */
+    private static class DummyIngredientQuantity extends IngredientQuantity {
+        private DummyIngredientQuantity() {
+            super(0, "");
+        }
+
+        public boolean hasSameUnitAs(IngredientQuantity other) {
+            return true;
+        }
+
+        @Override
+        public IngredientQuantity add(IngredientQuantity other) {
+            return other;
+        }
+
+        @Override
+        public IngredientQuantity subtract(IngredientQuantity other) {
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return "";
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof DummyIngredientQuantity;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(DummyIngredientQuantity.class);
+        }
+    }
 }

--- a/src/main/java/seedu/address/model/ingredient/UniqueIngredientList.java
+++ b/src/main/java/seedu/address/model/ingredient/UniqueIngredientList.java
@@ -7,6 +7,8 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -90,14 +92,20 @@ public class UniqueIngredientList implements Iterable<Ingredient> {
         if (!contains(toRemove)) {
             throw new IngredientNotFoundException();
         }
-        int index = internalList.indexOf(find(toRemove));
 
-        try {
-            Ingredient subtractedIngredient = find(toRemove).subtract(toRemove);
-            internalList.set(index, subtractedIngredient);
-        } catch (NonPositiveIngredientQuantityException e) {
-            internalList.remove(index);
-        }
+        this.setIngredients(internalList.stream()
+                .flatMap(ingredient -> {
+                    if (ingredient.isCompatibleWith(toRemove)) {
+                        try {
+                            Ingredient subtractedIngredient = ingredient.subtract(toRemove);
+                            return Stream.of(subtractedIngredient);
+                        } catch (NonPositiveIngredientQuantityException e) {
+                            return Stream.empty();
+                        }
+                    }
+                    return Stream.of(ingredient);
+                })
+                .collect(Collectors.toList()));
     }
 
     public void setIngredients(UniqueIngredientList replacement) {

--- a/src/test/java/seedu/address/logic/parser/inventory/InventoryRemoveIngredientCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/inventory/InventoryRemoveIngredientCommandParserTest.java
@@ -16,7 +16,6 @@ public class InventoryRemoveIngredientCommandParserTest {
         new IngredientQuantity("5"));
     private static final String VALID_INGREDIENT_ARGUMENT = " i/Ingredient q/5";
     private static final String INVALID_INGREDIENT_ARGUMENT_NO_NAME = " q/5";
-    private static final String INVALID_INGREDIENT_ARGUMENT_NO_QUANTITY = " i/Ingredient";
     private static final String INVALID_ARGUMENT = "Invalid argument";
 
     @Test
@@ -37,7 +36,5 @@ public class InventoryRemoveIngredientCommandParserTest {
         assertThrows(ParseException.class, () -> new InventoryRemoveIngredientCommandParser().parse(INVALID_ARGUMENT));
         assertThrows(ParseException.class, () ->
             new InventoryRemoveIngredientCommandParser().parse(INVALID_INGREDIENT_ARGUMENT_NO_NAME));
-        assertThrows(ParseException.class, () ->
-            new InventoryRemoveIngredientCommandParser().parse(INVALID_INGREDIENT_ARGUMENT_NO_QUANTITY));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/inventory/InventoryRemoveIngredientCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/inventory/InventoryRemoveIngredientCommandParserTest.java
@@ -16,6 +16,7 @@ public class InventoryRemoveIngredientCommandParserTest {
         new IngredientQuantity("5"));
     private static final String VALID_INGREDIENT_ARGUMENT = " i/Ingredient q/5";
     private static final String INVALID_INGREDIENT_ARGUMENT_NO_NAME = " q/5";
+    private static final String INVALID_INGREDIENT_ARGUMENT_NO_QUANTITY = " i/Ingredient";
     private static final String INVALID_ARGUMENT = "Invalid argument";
 
     @Test
@@ -36,5 +37,7 @@ public class InventoryRemoveIngredientCommandParserTest {
         assertThrows(ParseException.class, () -> new InventoryRemoveIngredientCommandParser().parse(INVALID_ARGUMENT));
         assertThrows(ParseException.class, () ->
             new InventoryRemoveIngredientCommandParser().parse(INVALID_INGREDIENT_ARGUMENT_NO_NAME));
+        assertThrows(ParseException.class, () ->
+            new InventoryRemoveIngredientCommandParser().parse(INVALID_INGREDIENT_ARGUMENT_NO_QUANTITY));
     }
 }


### PR DESCRIPTION
Did this by adding a `DummyIngredientQuantity` static class that allows subtraction of all of an ingredient quantity, regardless of the original quantity's value or unit. Updated the implementation of ingredient removal in `UniqueIngredientList`, and also updated the command parsers to use this dummy ingredient quantity when no quantity is specified.

It seems like a bit of a hack and I don't feel super comfortable with this, but I guess it follows from the restriction of quantities to only positive values. Does anyone have a better idea for how to implement this?
