### PR TITLE
Fix CookbookSearchByInventoryCommand not working properly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
 
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jUnitVersion
+    compile 'com.itextpdf:itextpdf:5.5.13.1'
 }
 
 shadowJar {

--- a/src/main/java/seedu/address/logic/commands/cart/CartExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/cart/CartExportCommand.java
@@ -1,0 +1,42 @@
+package seedu.address.logic.commands.cart;
+
+import java.io.IOException;
+
+import com.itextpdf.text.DocumentException;
+
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+/**
+ *  Exports the cart to a pdf file.
+ */
+public class CartExportCommand extends CartCommand {
+    public static final String COMMAND_WORD = "export";
+    public static final String MESSAGE_SUCCESS = "All cart ingredients have been exported to a pdf file!";
+    public static final String MESSAGE_USAGE = COMMAND_CATEGORY + " " + COMMAND_WORD
+        + "This commands allows you to export all ingredients inside the cart to a pdf file located in the same folder"
+        + "as Cooking Papa\n. Parameters for exporting all ingredients inside the cart is as follows:\n"
+        + COMMAND_CATEGORY + " " + COMMAND_WORD;
+
+    private static final String MESSAGE_FILE_NOT_FOUND = "File not found.";
+
+    public CartExportCommand() {
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        try {
+            model.exportCart();
+        } catch (IOException | DocumentException e) {
+            return new CommandResult(MESSAGE_FILE_NOT_FOUND);
+        }
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+                || other instanceof CartExportCommand;
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/cart/CartCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/cart/CartCommandParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.cart.CartAddCommand;
 import seedu.address.logic.commands.cart.CartClearCommand;
 import seedu.address.logic.commands.cart.CartCommand;
+import seedu.address.logic.commands.cart.CartExportCommand;
 import seedu.address.logic.commands.cart.CartRemoveIngredientCommand;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -49,6 +50,8 @@ public class CartCommandParser implements Parser<CartCommand> {
             return new CartRemoveIngredientCommandParser().parse(arguments);
         case CartClearCommand.COMMAND_WORD:
             return new CartClearCommandParser().parse(arguments);
+        case CartExportCommand.COMMAND_WORD:
+            return new CartExportCommandParser().parse(arguments);
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }

--- a/src/main/java/seedu/address/logic/parser/cart/CartExportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/cart/CartExportCommandParser.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.parser.cart;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.cart.CartCommand;
+import seedu.address.logic.commands.cart.CartExportCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ *  Parses input arguments and creates a new CartExportCommand object
+ */
+public class CartExportCommandParser implements Parser<CartCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the CartCommand
+     * and returns a CartExportCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format.
+     */
+    @Override
+    public CartExportCommand parse(String userInput) throws ParseException {
+        if (userInput.isEmpty()) {
+            return new CartExportCommand();
+        } else {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, CartExportCommand.MESSAGE_USAGE));
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/cookbook/CookbookSearchCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/cookbook/CookbookSearchCommandParser.java
@@ -27,6 +27,7 @@ public class CookbookSearchCommandParser implements Parser<CookbookSearchCommand
 
     private static final Pattern COOKBOOK_SEARCH_COMMAND_ARGUMENT_FORMAT = Pattern
             .compile(" *(?<category>recipe|tag|inventory)(?<arguments>.*)");
+
     /**
      * Parses the given {@code String} of arguments in the context of the CookbookSearchCommand
      * and returns a CookbookSearchCommand object for execution.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,7 +1,10 @@
 package seedu.address.model;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.function.Predicate;
+
+import com.itextpdf.text.DocumentException;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
@@ -177,6 +180,11 @@ public interface Model {
      */
     public Ingredient findCartIngredient(Ingredient ingredient);
 
+    /**
+     * Exports the ingredients in the cart to a pdf file.
+     */
+    public void exportCart() throws IOException, DocumentException;
+
     /** Returns an unmodifiable view of the filtered cookbook recipe list */
     ObservableList<Recipe> getFilteredCookbookRecipeList();
 
@@ -208,4 +216,6 @@ public interface Model {
      * Returns the MixedFraction value based on the similarity of the recipe.
      */
     MixedFraction calculateSimilarity(Recipe recipe);
+
+
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -3,9 +3,12 @@ package seedu.address.model;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
+
+import com.itextpdf.text.DocumentException;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
@@ -14,6 +17,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.fraction.MixedFraction;
 import seedu.address.model.ingredient.Ingredient;
 import seedu.address.model.recipe.Recipe;
+import seedu.address.model.util.PdfExporter;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -262,6 +266,11 @@ public class ModelManager implements Model {
     public void updateFilteredCartIngredientList(Predicate<Ingredient> predicate) {
         requireNonNull(predicate);
         filteredCartIngredients.setPredicate(predicate);
+    }
+
+    @Override
+    public void exportCart() throws IOException, DocumentException {
+        PdfExporter.exportCart(getFilteredCartIngredientList());
     }
 
     // TODO: Update method

--- a/src/main/java/seedu/address/model/ingredient/Ingredient.java
+++ b/src/main/java/seedu/address/model/ingredient/Ingredient.java
@@ -84,6 +84,10 @@ public class Ingredient {
                 && otherIngredient.getName().equals(getName());
     }
 
+    public String getNoWhitespaceName() {
+        return this.getName().ingredientName.replace(" ", "");
+    }
+
     /**
      * Returns true if both ingredients have the same name and quantity.
      * This defines a stronger notion of equality between two ingredients.
@@ -113,5 +117,4 @@ public class Ingredient {
     public String toString() {
         return String.format("%s %s", ingredientQuantity, ingredientName);
     }
-
 }

--- a/src/main/java/seedu/address/model/recipe/Recipe.java
+++ b/src/main/java/seedu/address/model/recipe/Recipe.java
@@ -81,11 +81,11 @@ public class Recipe {
         return sb.toString().trim().replace("[", "").replace("]", " ");
     }
 
-    public String getIngredientNamesString() {
+    public String getNoWhitespaceIngredientNamesString() {
         StringBuilder sb = new StringBuilder();
 
         for (Ingredient i : getIngredients()) {
-            sb.append(i.getName().ingredientName).append(" ");
+            sb.append(i.getName().ingredientName.replace(" ", "")).append(" ");
         }
 
         return sb.toString();

--- a/src/main/java/seedu/address/model/recipe/RecipeContainsInventoryIngredientsPredicate.java
+++ b/src/main/java/seedu/address/model/recipe/RecipeContainsInventoryIngredientsPredicate.java
@@ -16,12 +16,13 @@ public class RecipeContainsInventoryIngredientsPredicate implements Predicate<Re
 
     @Override
     public boolean test(Recipe recipe) {
-        if (recipe.getIngredientNamesString().length() == 0) {
+        if (recipe.getNoWhitespaceIngredientNamesString().length() == 0) {
             return false;
         }
 
         return inventory.getIngredientList().stream().anyMatch(ingredient ->
-            StringUtil.containsWordIgnoreCase(recipe.getIngredientNamesString(), ingredient.getName().ingredientName));
+            StringUtil.containsWordIgnoreCase(
+            recipe.getNoWhitespaceIngredientNamesString(), ingredient.getNoWhitespaceName()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/util/PdfExporter.java
+++ b/src/main/java/seedu/address/model/util/PdfExporter.java
@@ -1,0 +1,83 @@
+package seedu.address.model.util;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import com.itextpdf.text.BaseColor;
+import com.itextpdf.text.Chunk;
+import com.itextpdf.text.Document;
+import com.itextpdf.text.DocumentException;
+import com.itextpdf.text.Element;
+import com.itextpdf.text.Font;
+import com.itextpdf.text.Paragraph;
+import com.itextpdf.text.Phrase;
+import com.itextpdf.text.pdf.PdfPCell;
+import com.itextpdf.text.pdf.PdfPTable;
+import com.itextpdf.text.pdf.PdfWriter;
+
+import javafx.collections.ObservableList;
+import seedu.address.model.ingredient.Ingredient;
+
+
+
+/**
+ * Exports the given arguments to a pdf file.
+ */
+public class PdfExporter {
+
+    /**
+     * Exports the given list of {@code ingredients} from the cart to a pdf file.
+     * @param ingredients The list of ingredients in the cart.
+     * @throws IOException if cart.pdf is open and therefore unmodifiable.
+     */
+    public static void exportCart(ObservableList<Ingredient> ingredients) throws IOException, DocumentException {
+        Document document = new Document();
+        PdfWriter.getInstance(document, new FileOutputStream("cart.pdf"));
+
+        document.open();
+
+        Font font = new Font(Font.FontFamily.HELVETICA, 18, Font.BOLD);
+        Chunk title = new Chunk("Shopping List\n\n", font);
+        Phrase phrase = new Phrase();
+        phrase.add(title);
+        Paragraph paragraph = new Paragraph();
+        paragraph.add(phrase);
+        paragraph.setAlignment(Element.ALIGN_CENTER);
+
+        PdfPTable table = new PdfPTable(2);
+        addTableHeader(table);
+        addRows(table, ingredients);
+
+        document.add(paragraph);
+        document.add(table);
+        document.close();
+    }
+
+    /**
+     * Adds rows to a table for exporting a cart.
+     */
+    private static void addRows(PdfPTable table, ObservableList<Ingredient> ingredients) {
+        ingredients.forEach(ingredient -> {
+            table.addCell(ingredient.getName().toString());
+            table.addCell(ingredient.getQuantity().toString());
+        });
+    }
+
+    /**
+     * Adds headers to a table for exporting a cart.
+     */
+    private static void addTableHeader(PdfPTable table) {
+        Stream.of("Name", "Quantity")
+            .forEach(columnTitle -> {
+                Font bold = new Font(Font.FontFamily.HELVETICA, 12, Font.BOLD);
+                PdfPCell header = new PdfPCell();
+                header.setBackgroundColor(BaseColor.LIGHT_GRAY);
+                Phrase phrase = new Phrase(columnTitle, bold);
+                header.setPhrase(phrase);
+                header.setHorizontalAlignment(Element.ALIGN_CENTER);
+                table.addCell(header);
+            });
+    }
+
+}

--- a/src/main/java/seedu/address/model/util/PdfExporter.java
+++ b/src/main/java/seedu/address/model/util/PdfExporter.java
@@ -19,8 +19,6 @@ import com.itextpdf.text.pdf.PdfWriter;
 import javafx.collections.ObservableList;
 import seedu.address.model.ingredient.Ingredient;
 
-
-
 /**
  * Exports the given arguments to a pdf file.
  */

--- a/src/main/resources/view/RecipeListPanel.fxml
+++ b/src/main/resources/view/RecipeListPanel.fxml
@@ -6,6 +6,6 @@
 <?import javafx.scene.control.Label?>
 <VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
     <Label fx:id="header" styleClass="cell_header_label" alignment="CENTER"
-           text="                       Recipes"/>
+           text="                      Recipes"/>
     <ListView fx:id="recipeListView" VBox.vgrow="ALWAYS" />
 </VBox>

--- a/src/test/java/seedu/address/logic/commands/cart/CartExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/cart/CartExportCommandTest.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.commands.cart;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.logic.commands.cart.CartExportCommand.MESSAGE_SUCCESS;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+
+public class CartExportCommandTest {
+    @Test
+    public void execute_success() throws CommandException {
+        Model model = new ModelManager();
+        CartExportCommand c = new CartExportCommand();
+
+        // empty cart, cart.pdf must not be open
+        assertEquals(c.execute(model), new CommandResult(MESSAGE_SUCCESS));
+    }
+
+    @Test
+    public void equalsMethod() {
+        assertEquals(new CartExportCommand(), new CartExportCommand());
+        assertNotEquals(new CartExportCommand(), null);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/cart/CartExportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/cart/CartExportCommandParserTest.java
@@ -1,0 +1,25 @@
+package seedu.address.logic.parser.cart;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.cart.CartExportCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class CartExportCommandParserTest {
+    private static final String VALID_ARGUMENT = "";
+    private static final String INVALID_ARGUMENT = "Invalid argument";
+
+    @Test
+    public void parse_validInput() throws ParseException {
+        CartExportCommandParser c = new CartExportCommandParser();
+        assertEquals(c.parse(VALID_ARGUMENT), new CartExportCommand());
+    }
+
+    @Test
+    public void parse_invalidInput() {
+        assertThrows(ParseException.class, () -> new CartExportCommandParser().parse(INVALID_ARGUMENT));
+    }
+}


### PR DESCRIPTION
- Modify RecipeContainsInventoryIngredientsPredicate#test to remove whitespaces in ingredient names and recipe's ingredients
- Add `CartExportCommand`
- Add `CartExportCommandParser`
- Add `PdfExporter`
- Add `CartExportCommandTest`
- Add `CartExportCommandParserTest`