### PR TITLE
Fix ingredient quantity regex

### DIFF
--- a/src/main/java/seedu/address/model/ingredient/IngredientQuantity.java
+++ b/src/main/java/seedu/address/model/ingredient/IngredientQuantity.java
@@ -19,11 +19,12 @@ import seedu.address.model.ingredient.exceptions.NonPositiveIngredientQuantityEx
 public class IngredientQuantity {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Ingredient quantities should only contain a value and a unit, where the value can be "
+            "Ingredient quantities should only contain a positive value and a unit, where the value can be "
             + "whole numbers, decimals, or fractions, and the unit should only contain alphabets";
 
-    private static final String DECIMAL_REGEX = "(([\\p{Digit}]+(\\.[\\p{Digit}]+)?)|(\\.[\\p{Digit}]+))";
-    private static final String FRACTION_REGEX = "[\\p{Digit}]+( +[\\p{Digit}]+)?/[\\p{Digit}]+";
+    private static final String DECIMAL_REGEX = "([1-9][\\p{Digit}]*(\\.[\\p{Digit}]+)?)"
+            + "|(0?\\.(?=.*[1-9])[\\p{Digit}]+)";
+    private static final String FRACTION_REGEX = "[1-9][\\p{Digit}]*( +[1-9][\\p{Digit}]*)?/[1-9][\\p{Digit}]*";
     private static final String UNIT_REGEX = "[\\p{Alpha}][\\p{Alpha} ]*";
 
     /*

--- a/src/test/java/seedu/address/model/ingredient/IngredientQuantityTest.java
+++ b/src/test/java/seedu/address/model/ingredient/IngredientQuantityTest.java
@@ -34,6 +34,15 @@ public class IngredientQuantityTest {
         assertFalse(IngredientQuantity.isValidIngredientQuantity("1.")); // whole number with decimal point
         assertFalse(IngredientQuantity.isValidIngredientQuantity("1 / 2 cups")); // spaces in fraction
         assertFalse(IngredientQuantity.isValidIngredientQuantity("1 piece1")); // number in unit
+        assertFalse(IngredientQuantity.isValidIngredientQuantity("01 g")); // leading zero
+        assertFalse(IngredientQuantity.isValidIngredientQuantity("0 g")); // zero whole number
+        assertFalse(IngredientQuantity.isValidIngredientQuantity("0.0 g")); // zero decimal
+        assertFalse(IngredientQuantity.isValidIngredientQuantity(".0 g")); // zero value
+        assertFalse(IngredientQuantity.isValidIngredientQuantity("0/1 g")); // zero numerator
+        assertFalse(IngredientQuantity.isValidIngredientQuantity("1/0 g")); // zero denominator
+        assertFalse(IngredientQuantity.isValidIngredientQuantity("0 1/2 g")); // zero whole part
+        assertFalse(IngredientQuantity.isValidIngredientQuantity("-1.2 g")); // negative decimal
+        assertFalse(IngredientQuantity.isValidIngredientQuantity("-1/2 g")); // negative fraction
 
         // valid ingredient quantity
         assertTrue(IngredientQuantity.isValidIngredientQuantity("12345")); // whole number


### PR DESCRIPTION
Previously, ingredient quantities with a value of 0 could be added via the commands.